### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+# Re-use the publishing workflow from smqtk-core
+name: Publish
+
+on:
+  push:
+    tags:
+      # Only run on tags with official version tag release format (e.g. v1.0.1)
+      - "v[0-9].[0-9]+.[0-9]+"
+
+jobs:
+  reuse-core-publish:
+    uses: Kitware/SMQTK-Core/.github/workflows/publish.yml@master
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -4,6 +4,10 @@ Pending Release Notes
 Updates / New Features
 ----------------------
 
+CI
+
+* Add workflow to inherit the smqtk-core publish workflow.
+
 Features
 
 * Added `ResNetFRCNN` implementation of `DetectImageObjects` that relies on,

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -20,5 +20,10 @@ Features
 * Moved, and added to, interface convenience exposure to the package root
   module.
 
+Miscellaneous
+
+* Added a wrapper script to pull the versioning/changelog update helper from
+  smqtk-core to use here without duplication.
+
 Fixes
 -----

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+/.dl_script_cache.sh
+/.pending_notes_stub.rst

--- a/scripts/update_release_notes.sh
+++ b/scripts/update_release_notes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Wrapper to pull and invoke the "common" script of the same name from the
+# smqtk-core repository.
+#
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+URL_SCRIPT="https://raw.githubusercontent.com/Kitware/SMQTK-Core/master/scripts/update_release_notes.sh"
+URL_STUB="https://raw.githubusercontent.com/Kitware/SMQTK-Core/master/scripts/.pending_notes_stub.rst"
+DL_SCRIPT="${SCRIPT_DIR}/.dl_script_cache.sh"
+DL_STUB="${SCRIPT_DIR}/.pending_notes_stub.rst"
+
+if [[ ! -f "$DL_SCRIPT" ]]
+then
+  curl -sSL "$URL_SCRIPT" -o "$DL_SCRIPT"
+  curl -sSL "$URL_STUB" -o "$DL_STUB"
+fi
+
+bash "$DL_SCRIPT" "$@"


### PR DESCRIPTION
Invokes smqtk-core publish workflow for reuse.

Depends on kitware/smqtk-core#56 to provide the update to the workflow being reused.