### PR TITLE
Add CI workaround for invalid wheels

### DIFF
--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -126,6 +126,10 @@ jobs:
         run: |
           if [[ -n "$OPT_EXTRA" ]]
           then
+            # Workaround: Poetry 1.4.1 introduced stricter checks on wheels
+            # https://github.com/python-poetry/poetry/issues/7686
+            export POETRY_INSTALLER_MODERN_INSTALLATION=false
+
             poetry install --extras "$OPT_EXTRA"
           fi
 


### PR DESCRIPTION
The release of Poetry 1.4.1 started carrying out stricter validation checks on wheels causing errors for many packages: [https://github.com/python-poetry/poetry/issues/7686](https://github.com/python-poetry/poetry/issues/7686). Within `smqtk-detection`, this is causing an installation failure due to an invalid `torch` wheel leading to failing CI tests. This adds a workaround to allow CI to continue until a more appropriate solution can be applied.

The broken `torch` package has already been reported on the pytorch repo: [https://github.com/pytorch/pytorch/issues/97153](https://github.com/pytorch/pytorch/issues/97153).
