### PR TITLE
Fix doc webpage link in pyproject.toml

### DIFF
--- a/docs/readthedocs-reqs.txt
+++ b/docs/readthedocs-reqs.txt
@@ -1,3 +1,4 @@
 # SMQTK-Detection specific documentation depedencies
 sphinx-argparse==0.2.5
 sphinx-prompt==1.3.0
+sphinx-rtd-theme==1.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 authors = ["Kitware, Inc. <smqtk-developers@kitware.com>"]
 readme = "README.md"
 repository = "https://github.com/Kitware/SMQTK-Detection"
-documentation = ""
+documentation = "https://smqtk-detection.readthedocs.io/"
 classifiers = [
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -5,12 +5,14 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+
 python:
-  version: 3.8
   install:
     - requirements: docs/readthedocs-reqs.txt
     - method: pip
       path: .
+
 sphinx:
   builder: html
   configuration: docs/conf.py
+  

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,4 +1,4 @@
-version: 3
+version: 2
 formats:
   - pdf
 python:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,6 +1,10 @@
 version: 2
 formats:
   - pdf
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 python:
   version: 3.8
   install:

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 formats:
   - pdf
 python:


### PR DESCRIPTION
This PR adds the doc webpage link to the pyproject.toml file.