### PR TITLE
Switch malformed bbox warnings to debug logging

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -10,7 +10,8 @@ Updates / New Features
   malformed bboxes are encountered. If ``True``, bbox vertices will be sorted such that (``max_vertex >= min_vertex``),
   otherwise, (new default) the offending detection will be dropped from the list of detections completely. This new
   default is similar to previous behavior, but avoids hitting the exception such that the remaining well-formed
-  detections can be returned.
+  detections can be returned. Debug logging may be enabled to have more visibility into when malformed bboxes are
+  encountered.
 
 Fixes
 -----

--- a/smqtk_detection/impls/detect_image_objects/centernet.py
+++ b/smqtk_detection/impls/detect_image_objects/centernet.py
@@ -377,19 +377,13 @@ class CenterNetVisdrone(DetectImageObjects):
             # If max vertex < min vertex, reorder/reject detection based on config
             if not (det[2:4] >= det[0:2]).all():
                 if self.reorder_malformed_bboxes:
-                    warnings.warn(
-                        f"Reordering malformed bbox: {det[0:4]}",
-                        RuntimeWarning,
-                    )
+                    logger.debug(f"Reordering malformed bbox: {det[0:4]}")
                     if det[2] < det[0]:
                         det[0], det[2] = det[2], det[0]
                     if det[3] < det[1]:
                         det[1], det[3] = det[3], det[1]
                 else:
-                    warnings.warn(
-                        f"Skipping malformed bbox: {det[0:4]}",
-                        RuntimeWarning,
-                    )
+                    logger.debug(f"Skipping malformed bbox: {det[0:4]}")
                     continue
 
             bbox = AxisAlignedBoundingBox(det[0:2], det[2:4])

--- a/tests/impls/detect_image_objects/test_centernetvisdrone.py
+++ b/tests/impls/detect_image_objects/test_centernetvisdrone.py
@@ -222,21 +222,17 @@ class TestCenterNetVisdrone:
             "mock path",
             reorder_malformed_bboxes=True,
         )
-        with pytest.warns(RuntimeWarning) as reorder_record:
-            reorder_out = reorder_inst._dets_mat_to_list(np.copy(mock_dets))
+        reorder_out = reorder_inst._dets_mat_to_list(np.copy(mock_dets))
         assert len(reorder_out) == mock_dets.shape[0]
         assert reorder_out[0][0] == reorder_out[1][0]
-        assert "Reordering" in str(reorder_record[0].message)
 
         drop_inst = CenterNetVisdrone(
             "resnet18",
             "mock path",
             reorder_malformed_bboxes=False,
         )
-        with pytest.warns(RuntimeWarning) as drop_record:
-            drop_out = drop_inst._dets_mat_to_list(np.copy(mock_dets))
+        drop_out = drop_inst._dets_mat_to_list(np.copy(mock_dets))
         assert len(drop_out) == mock_dets.shape[0] - 1
-        assert "Skipping" in str(drop_record[0].message)
 
 
 def mock_model_forward(img_tensors: "torch.Tensor") -> Dict:  # noqa: F821


### PR DESCRIPTION
Switch to debug logging instead of warnings when malformed bboxes are encountered